### PR TITLE
[Task-2]:

### DIFF
--- a/auth-service/src/domain/error.rs
+++ b/auth-service/src/domain/error.rs
@@ -1,0 +1,5 @@
+pub enum AuthAPIError {
+    UserAlreadyExists,
+    InvalidCredentials,
+    UnexpectedError,
+}

--- a/auth-service/src/domain/mod.rs
+++ b/auth-service/src/domain/mod.rs
@@ -1,3 +1,5 @@
+mod error;
 mod user;
 
+pub use error::*;
 pub use user::*;

--- a/auth-service/src/lib.rs
+++ b/auth-service/src/lib.rs
@@ -1,14 +1,23 @@
-use crate::app_state::AppState;
+use {
+    app_state::AppState,
+    axum::{
+        http::StatusCode,
+        response::{IntoResponse, Response},
+        routing::post,
+        serve::Serve,
+        Json, Router,
+    },
+    domain::AuthAPIError,
+    serde::{Deserialize, Serialize},
+    std::error::Error,
+    tower_http::services::ServeDir,
+};
 
-use axum::{routing::post, serve::Serve, Router};
-use std::error::Error;
-use tower_http::services::ServeDir;
-
+mod api;
 pub mod app_state;
+mod domain;
 pub mod routes;
 pub mod services;
-mod api;
-mod domain;
 
 pub struct Application {
     server: Serve<Router, Router>,
@@ -37,5 +46,28 @@ impl Application {
     pub async fn run(self) -> Result<(), std::io::Error> {
         println!("Listening on {}...", &self.address);
         self.server.await
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ErrorResponse {
+    pub error: String,
+}
+
+impl IntoResponse for AuthAPIError {
+    fn into_response(self) -> Response {
+        let (status, error_message) = match self {
+            AuthAPIError::UserAlreadyExists => (StatusCode::CONFLICT, "User already exists"),
+            AuthAPIError::InvalidCredentials => (StatusCode::BAD_REQUEST, "Invalid credentials"),
+            AuthAPIError::UnexpectedError => {
+                (StatusCode::INTERNAL_SERVER_ERROR, "Unexpected error")
+            }
+        };
+
+        let body = Json(ErrorResponse {
+            error: error_message.to_string(),
+        });
+
+        (status, body).into_response()
     }
 }

--- a/auth-service/src/routes/signup.rs
+++ b/auth-service/src/routes/signup.rs
@@ -1,9 +1,13 @@
-use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
-use serde::{Deserialize, Serialize};
+use {
+    crate::{
+        app_state::AppState,
+        domain::{AuthAPIError, User},
+    },
+    axum::{extract::State, http::StatusCode, response::IntoResponse, Json},
+    serde::{Deserialize, Serialize},
+};
 
-use crate::{app_state::AppState, domain::User, services::UserStoreError};
-
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SignupRequest {
     pub email: String,
     pub password: String,
@@ -16,52 +20,30 @@ pub struct SignupResponse {
     pub message: String,
 }
 
-pub async fn signup_handler(Json(request): Json<SignupRequest>) -> impl IntoResponse {
-    StatusCode::OK.into_response()
-}
-
 pub async fn signup(
-    state: State<AppState>,
+    State(state): State<AppState>,
     Json(request): Json<SignupRequest>,
-) -> impl IntoResponse {
-    let mut user_store = state.user_store.write().await;
+) -> Result<impl IntoResponse, AuthAPIError> {
+    let is_invalid =
+        request.email.is_empty() || !request.email.contains('@') || request.password.len() < 8;
 
-    if request.password.len() < 8 {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(SignupResponse {
-                message: "Password is too short.".to_string(),
-            }),
-        );
-    }
-
-    if request.email.is_empty() {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(SignupResponse {
-                message: "Email cannot be empty.".to_string(),
-            }),
-        );
-    }
-
-    if !request.email.contains('@') {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(SignupResponse {
-                message: "Invalid email format.".to_string(),
-            }),
-        );
+    if is_invalid {
+        return Err(AuthAPIError::InvalidCredentials);
     }
 
     let user = User::new(request.email, request.password, request.requires_2fa);
-    user_store.add_user(user).unwrap();
+    let mut user_store = state.user_store.write().await;
 
-    (
+    if let Err(_) = user_store.add_user(user) {
+        return Err(AuthAPIError::UserAlreadyExists);
+    };
+
+    Ok((
         StatusCode::CREATED,
         Json(SignupResponse {
             message: "User created successfully!".to_string(),
         }),
-    )
+    ))
 }
 
 pub async fn signup_malformed_request_422() -> impl IntoResponse {

--- a/auth-service/src/services/hashmap_user_store.rs
+++ b/auth-service/src/services/hashmap_user_store.rs
@@ -17,7 +17,7 @@ pub struct HashmapUserStore {
 
 impl HashmapUserStore {
     pub fn add_user(&mut self, user: User) -> Result<(), UserStoreError> {
-        match self.users.entry(user.email().to_owned()) {
+        match self.users.entry(user.email().to_string()) {
             Entry::Occupied(_) => Err(UserStoreError::UserAlreadyExists),
             Entry::Vacant(entry) => {
                 entry.insert(user);

--- a/auth-service/tests/api/signup.rs
+++ b/auth-service/tests/api/signup.rs
@@ -1,16 +1,19 @@
-use crate::helpers::{get_random_email, get_random_password, TestApp};
-use auth_service::{
-    app_state::AppState,
-    routes::{signup, SignupRequest, SignupResponse},
-    services::HashmapUserStore,
+use {
+    crate::helpers::{get_random_email, get_random_password, TestApp},
+    auth_service::{
+        app_state::AppState,
+        routes::{signup, SignupRequest, SignupResponse},
+        services::{HashmapUserStore, UserStoreError},
+        ErrorResponse,
+    },
+    axum::{
+        extract::State,
+        http::StatusCode,
+        response::{IntoResponse, Response},
+    },
+    std::sync::Arc,
+    tokio::sync::RwLock,
 };
-use axum::{
-    extract::State,
-    http::StatusCode,
-    response::{IntoResponse, Response},
-};
-use std::sync::Arc;
-use tokio::sync::RwLock;
 
 #[tokio::test]
 async fn should_return_422_if_malformed_input() {
@@ -110,43 +113,55 @@ pub async fn should_return_201_if_valid_input() {
 
 #[tokio::test]
 pub async fn should_return_400_if_invalid_input() {
-    // The signup route should return a 400 HTTP status code if an invalid input is sent.
-    // The input is considered invalid if:
-    // - The email is empty or does not contain '@'
-    // - The password is less than 8 characters
-
-    // Create an array of invalid inputs. Then, iterate through the array and
-    // make HTTP calls to the signup route. Assert a 400 HTTP status code is returned.
+    let app = TestApp::new().await;
 
     let test_cases = [
-        axum::Json(SignupRequest {
+        serde_json::json!(SignupRequest {
             email: "randomemail.com".to_string(),
             password: get_random_password(),
             requires_2fa: true,
         }),
-        axum::Json(SignupRequest {
+        serde_json::json!(SignupRequest {
             email: get_random_email(),
-            password: "12345".to_string(),
+            password: "1234567".to_string(),
             requires_2fa: true,
         }),
-        axum::Json(SignupRequest {
+        serde_json::json!(SignupRequest {
             email: get_random_email(),
             password: "".to_string(),
             requires_2fa: true,
         }),
     ];
 
-    let user_store = Arc::new(RwLock::new(HashmapUserStore::default()));
-
-    let state = State(AppState::new(user_store));
-
     for test_case in test_cases {
-        let response = signup(state.clone(), test_case).await.into_response();
+        let response = app.post_signup(&test_case).await;
 
         assert_eq!(
-            response.status(),
-            StatusCode::BAD_REQUEST,
-            "Expect to return 400 - BAD_REQUEST."
-        )
+            response.status().as_u16(),
+            400,
+            "Failed for input: {:?}",
+            test_case
+        );
     }
+}
+
+#[tokio::test]
+pub async fn should_return_409_if_email_already_exists() {
+    let app = TestApp::new().await;
+
+    let user = serde_json::json!(SignupRequest {
+        email: get_random_email(),
+        password: get_random_password(),
+        requires_2fa: true,
+    });
+
+    app.post_signup(&user).await;
+
+    let response = app.post_signup(&user).await;
+
+    assert_eq!(
+        response.status().as_u16(),
+        409,
+        "Expects to return 409 - CONFLICT."
+    )
 }


### PR DESCRIPTION
Add invalid input validation tests for signup endpoint

- Implement should_return_400_if_invalid_input test to verify proper validation
- Test cases cover invalid email formats (missing @), passwords under 8 characters, and empty passwords
- Ensure signup endpoint returns 400 Bad Request for invalid inputs per validation rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Signup now accepts a requires2FA flag.
  - API returns structured JSON error responses with clear messages and appropriate HTTP status codes (e.g., 409 for existing email, 400 for invalid input).
- Refactor
  - Unified signup validation and error handling, returning standardized responses on failure.
- Tests
  - Added coverage for conflict on duplicate signup and refined tests to validate new error responses and status codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->