### PR TITLE
[Task-3]

### DIFF
--- a/auth-service/Cargo.lock
+++ b/auth-service/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
 name = "auth-service"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "reqwest",
  "serde",

--- a/auth-service/Cargo.toml
+++ b/auth-service/Cargo.toml
@@ -13,3 +13,4 @@ reqwest = { version = "0.11.26", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.7.0", features = ["v4", "serde"] }
+async-trait = "0.1.78"

--- a/auth-service/src/app_state/app_state.rs
+++ b/auth-service/src/app_state/app_state.rs
@@ -1,9 +1,9 @@
-use crate::services::HashmapUserStore;
+use crate::domain::UserStore;
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub type UserStoreType = Arc<RwLock<HashmapUserStore>>;
+pub type UserStoreType = Arc<RwLock<dyn UserStore>>;
 
 #[derive(Clone)]
 pub struct AppState {

--- a/auth-service/src/domain/data_store.rs
+++ b/auth-service/src/domain/data_store.rs
@@ -1,0 +1,18 @@
+use crate::domain::User;
+
+#[async_trait::async_trait]
+pub trait UserStore: Send + Sync {
+    async fn add_user(&mut self, user: User) -> Result<(), UserStoreError>;
+
+    async fn get_user(&self, email: &str) -> Result<User, UserStoreError>;
+
+    async fn validate_user(&self, email: &str, password: &str) -> Result<(), UserStoreError>;
+}
+
+#[derive(Debug, PartialEq)]
+pub enum UserStoreError {
+    UserAlreadyExists,
+    UserNotFound,
+    InvalidCredentials,
+    UnexpectedError,
+}

--- a/auth-service/src/domain/mod.rs
+++ b/auth-service/src/domain/mod.rs
@@ -1,5 +1,7 @@
+mod data_store;
 mod error;
 mod user;
 
+pub use data_store::*;
 pub use error::*;
 pub use user::*;

--- a/auth-service/src/lib.rs
+++ b/auth-service/src/lib.rs
@@ -1,17 +1,17 @@
-use {
-    app_state::AppState,
-    axum::{
-        http::StatusCode,
-        response::{IntoResponse, Response},
-        routing::post,
-        serve::Serve,
-        Json, Router,
-    },
-    domain::AuthAPIError,
-    serde::{Deserialize, Serialize},
-    std::error::Error,
-    tower_http::services::ServeDir,
+use app_state::AppState;
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::post,
+    serve::Serve,
+    Json, Router,
 };
+use domain::AuthAPIError;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use tower_http::services::ServeDir;
+
+use crate::domain::UserStore;
 
 mod api;
 pub mod app_state;

--- a/auth-service/src/routes/signup.rs
+++ b/auth-service/src/routes/signup.rs
@@ -1,10 +1,9 @@
-use {
-    crate::{
-        app_state::AppState,
-        domain::{AuthAPIError, User},
-    },
-    axum::{extract::State, http::StatusCode, response::IntoResponse, Json},
-    serde::{Deserialize, Serialize},
+use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    app_state::AppState,
+    domain::{AuthAPIError, User},
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -32,9 +31,10 @@ pub async fn signup(
     }
 
     let user = User::new(request.email, request.password, request.requires_2fa);
+
     let mut user_store = state.user_store.write().await;
 
-    if let Err(_) = user_store.add_user(user) {
+    if let Err(_) = user_store.add_user(user).await {
         return Err(AuthAPIError::UserAlreadyExists);
     };
 

--- a/auth-service/tests/api/signup.rs
+++ b/auth-service/tests/api/signup.rs
@@ -1,19 +1,6 @@
-use {
-    crate::helpers::{get_random_email, get_random_password, TestApp},
-    auth_service::{
-        app_state::AppState,
-        routes::{signup, SignupRequest, SignupResponse},
-        services::{HashmapUserStore, UserStoreError},
-        ErrorResponse,
-    },
-    axum::{
-        extract::State,
-        http::StatusCode,
-        response::{IntoResponse, Response},
-    },
-    std::sync::Arc,
-    tokio::sync::RwLock,
-};
+use auth_service::routes::{SignupRequest, SignupResponse};
+
+use crate::helpers::{get_random_email, get_random_password, TestApp};
 
 #[tokio::test]
 async fn should_return_422_if_malformed_input() {


### PR DESCRIPTION
Refactor user store to use trait abstraction for async operations

Extract UserStore trait and UserStoreError enum into domain layer to enable flexible storage implementations. Convert HashmapUserStore to implement the new trait pattern with async methods, improving testability and allowing for future database integrations.

Changes:
- Add async-trait dependency for trait async method support
- Create data_store module with UserStore trait and UserStoreError enum
- Update AppState to use dyn UserStore instead of concrete HashmapUserStore
- Convert all UserStore methods to async (add_user, get_user, validate_user)
- Update get_user to return owned User instead of reference for thread safety
- Refactor signup route and tests to use async/await with new interface
- Reorganize imports for better code organization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added application bootstrap to initialize and run the server.
  * Standardized JSON error responses with appropriate HTTP status codes.

* Refactor
  * Switched user data storage to an asynchronous, pluggable abstraction to improve flexibility and concurrency.
  * Updated signup flow to use async operations without changing behavior.

* Tests
  * Simplified test imports for clarity and maintainability.

* Chores
  * Added an asynchronous utility dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->