### PR TITLE
Implement logout endpoint with JWT validation and CORS support

### DIFF
--- a/auth-service/Cargo.lock
+++ b/auth-service/Cargo.lock
@@ -55,7 +55,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tower-http",
+ "tower-http 0.5.2",
  "uuid",
  "validator",
 ]
@@ -1136,7 +1136,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.6.6",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1454,30 +1454,45 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags",
  "bytes",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "http-range-header",
  "httpdate",
- "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/auth-service/Cargo.toml
+++ b/auth-service/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 axum = "0.7.4"
 axum-extra = { version = "0.9.2", features = ["cookie"] }
 tokio = { version = "1.36", features = ["full"] }
-tower-http = { version = "0.6.6", features = ["fs"] }
+tower-http = { version = "0.5.0", features = ["fs", "cors"] }
 reqwest = { version = "0.12.24", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.145"

--- a/auth-service/src/domain/error.rs
+++ b/auth-service/src/domain/error.rs
@@ -4,5 +4,7 @@ pub enum AuthAPIError {
     InvalidCredentials,
     IncorrectCredentials,
     UnexpectedError,
-    UnprocessableContent,
+    // UnprocessableContent,
+    InvalidToken,
+    MissingToken,
 }

--- a/auth-service/src/main.rs
+++ b/auth-service/src/main.rs
@@ -1,4 +1,4 @@
-use auth_service::{app_state::AppState, services::HashmapUserStore, Application};
+use auth_service::{app_state::AppState, services::HashmapUserStore, utils::prod, Application};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -7,7 +7,7 @@ async fn main() {
     let user_store = Arc::new(RwLock::new(HashmapUserStore::default()));
     let app_state = AppState::new(user_store);
 
-    let app = Application::build(app_state, "0.0.0.0:3000")
+    let app = Application::build(app_state, prod::APP_ADDRESS)
         .await
         .expect("Failed to build app.");
 

--- a/auth-service/src/routes/logout.rs
+++ b/auth-service/src/routes/logout.rs
@@ -1,5 +1,27 @@
-use axum::{http::StatusCode, response::IntoResponse};
+use crate::{
+    domain::AuthAPIError,
+    utils::{validate_token, JWT_COOKIE_NAME},
+};
 
-pub async fn logout_handler() -> impl IntoResponse {
-    StatusCode::OK.into_response()
+use axum::{http::StatusCode, response::IntoResponse};
+use axum_extra::extract::CookieJar;
+
+pub async fn logout_handler(
+    cookie_jar: CookieJar,
+) -> (CookieJar, Result<impl IntoResponse, AuthAPIError>) {
+    let cookie = match cookie_jar.get(JWT_COOKIE_NAME) {
+        Some(cookie) => cookie,
+        None => return (cookie_jar, Err(AuthAPIError::MissingToken)),
+    };
+
+    let token = cookie.value().to_owned();
+
+    match validate_token(&token).await {
+        Ok(_) => {}
+        Err(_) => return (cookie_jar, Err(AuthAPIError::InvalidToken)),
+    };
+
+    let cookie_jar = cookie_jar.remove(JWT_COOKIE_NAME);
+
+    (cookie_jar, Ok(StatusCode::OK))
 }

--- a/auth-service/src/utils/constants.rs
+++ b/auth-service/src/utils/constants.rs
@@ -12,6 +12,14 @@ pub mod env {
     pub const JWT_SECRET_ENV_VAR: &str = "JWT_SECRET";
 }
 
+pub mod prod {
+    pub const APP_ADDRESS: &str = "0.0.0.0:3000";
+}
+
+pub mod test {
+    pub const APP_ADDRESS: &str = "127.0.0.1:0";
+}
+
 fn set_token() -> String {
     dotenv().ok();
 

--- a/auth-service/tests/api/helpers.rs
+++ b/auth-service/tests/api/helpers.rs
@@ -1,13 +1,15 @@
-use auth_service::{app_state::AppState, services::HashmapUserStore, Application};
+use auth_service::{app_state::AppState, services::HashmapUserStore, utils::test, Application};
 use fake::{
     faker::internet::en::{self, SafeEmail},
     Fake,
 };
+use reqwest::cookie::Jar;
 use std::{ops::Range, sync::Arc};
 use tokio::sync::RwLock;
 
 pub struct TestApp {
     pub address: String,
+    pub cookie_jar: Arc<Jar>,
     pub http_client: reqwest::Client,
 }
 
@@ -15,9 +17,8 @@ impl TestApp {
     pub async fn new() -> Self {
         let user_store = Arc::new(RwLock::new(HashmapUserStore::default()));
         let app_state = AppState::new(user_store);
-        let address = "127.0.0.1:0";
 
-        let app = Application::build(app_state, address)
+        let app = Application::build(app_state, test::APP_ADDRESS)
             .await
             .expect("Failed to build app");
 
@@ -28,10 +29,15 @@ impl TestApp {
         #[allow(clippy::let_underscore_future)]
         let _ = tokio::spawn(app.run());
 
-        let http_client = reqwest::Client::new();
+        let cookie_jar = Arc::new(Jar::default());
+        let http_client = reqwest::Client::builder()
+            .cookie_provider(cookie_jar.clone())
+            .build()
+            .unwrap();
 
         TestApp {
             address,
+            cookie_jar,
             http_client,
         }
     }
@@ -68,7 +74,7 @@ impl TestApp {
             .expect("Failed to execute request.")
     }
 
-    pub async fn logout_root(&self) -> reqwest::Response {
+    pub async fn post_logout(&self) -> reqwest::Response {
         self.http_client
             .post(&format!("{}/logout", &self.address))
             .send()

--- a/auth-service/tests/api/logout.rs
+++ b/auth-service/tests/api/logout.rs
@@ -1,9 +1,78 @@
 use crate::helpers::TestApp;
 
-#[tokio::test]
-pub async fn root_returns_logout() {
-    let app = TestApp::new().await;
-    let response = app.logout_root().await;
+use auth_service::{
+    api::get_random_email,
+    domain::Email,
+    utils::{generate_auth_cookie, JWT_COOKIE_NAME},
+};
+use reqwest::Url;
 
-    assert_eq!(response.status().as_u16(), 200);
+#[tokio::test]
+async fn should_return_200_if_valid_jwt_cookie() {
+    let app = TestApp::new().await;
+
+    let email = Email::parse(get_random_email()).unwrap();
+    let cookie = generate_auth_cookie(&email).unwrap();
+
+    app.cookie_jar.add_cookie_str(
+        &format!(
+            "{}={}; HttpOnly; SameSite=Lax; Secure; Path=/",
+            JWT_COOKIE_NAME,
+            cookie.value()
+        ),
+        &Url::parse("http://127.0.0.1").expect("Failed to parse URL"),
+    );
+
+    let response = app.post_logout().await;
+
+    assert_eq!(response.status().as_u16(), 200)
+}
+
+#[tokio::test]
+async fn should_return_400_if_logout_called_twice_in_a_row() {
+    let app = TestApp::new().await;
+
+    let email = Email::parse(get_random_email()).unwrap();
+    let cookie = generate_auth_cookie(&email).unwrap();
+
+    app.cookie_jar.add_cookie_str(
+        &format!(
+            "{}={}; HttpOnly; SameSite=Lax; Secure; Path=/",
+            JWT_COOKIE_NAME,
+            cookie.value()
+        ),
+        &Url::parse("http://127.0.0.1").expect("Failed to parse URL"),
+    );
+
+    app.post_logout().await;
+    let response = app.post_logout().await;
+
+    assert_eq!(response.status().as_u16(), 400)
+}
+
+#[tokio::test]
+async fn should_return_400_if_jwt_cookie_missing() {
+    let app = TestApp::new().await;
+
+    let response = app.post_logout().await;
+
+    assert_eq!(response.status().as_u16(), 400)
+}
+
+#[tokio::test]
+async fn should_return_401_if_invalid_token() {
+    let app = TestApp::new().await;
+
+    // add invalid cookie
+    app.cookie_jar.add_cookie_str(
+        &format!(
+            "{}=invalid; HttpOnly; SameSite=Lax; Secure; Path=/",
+            JWT_COOKIE_NAME
+        ),
+        &Url::parse("http://127.0.0.1").expect("Failed to parse URL"),
+    );
+
+    let response = app.post_logout().await;
+
+    assert_eq!(response.status().as_u16(), 401)
 }


### PR DESCRIPTION
Add complete logout functionality with proper JWT token validation:
- Implement logout handler that validates JWT cookie before logout
- Add MissingToken and InvalidToken error variants to AuthAPIError
- Remove JWT cookie on successful logout
- Return appropriate error responses (400 for missing token, 401 for invalid)

Add CORS configuration:
- Configure CORS layer to allow credentials and specified origins
- Support localhost:8000 for local development

Refactor application configuration:
- Move APP_ADDRESS constants to utils module (prod/test configs)
- Update prod config to bind to 0.0.0.0:3000 for Docker compatibility
- Update test config to use 127.0.0.1:0 for random test ports

Enhance test infrastructure:
- Add cookie jar support to TestApp for cookie-based testing
- Refactor logout tests with comprehensive coverage:
  * Valid JWT cookie returns 200
  * Calling logout twice returns 400 (missing cookie)
  * Missing JWT cookie returns 400
  * Invalid token returns 401

Dependencies:
- Downgrade tower-http to 0.5.0 for CORS feature compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Cross-Origin Resource Sharing (CORS) support for API requests.

* **Bug Fixes**
  * Improved JWT token validation during logout with proper error handling for missing or invalid tokens.

* **Tests**
  * Expanded logout functionality test coverage with comprehensive scenarios including valid tokens, invalid tokens, and repeated logout attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->