### PR TITLE
Implement JWT token verification endpoint

### DIFF
--- a/auth-service/src/routes/verify_token.rs
+++ b/auth-service/src/routes/verify_token.rs
@@ -1,5 +1,21 @@
-use axum::{http::StatusCode, response::IntoResponse};
+use crate::{domain::AuthAPIError, utils::validate_token};
 
-pub async fn verify_token_handler() -> impl IntoResponse {
-    StatusCode::OK.into_response()
+use axum::{response::IntoResponse, Json};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct VerifyTokenRequest {
+    token: String,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub struct VerifyTokenResponse {
+    message: String,
+}
+
+pub async fn verify_token_handler(Json(request): Json<VerifyTokenRequest>) -> impl IntoResponse {
+    match validate_token(&request.token).await {
+        Ok(_) => Ok(()),
+        Err(_) => Err(AuthAPIError::InvalidCredentials),
+    }
 }

--- a/auth-service/tests/api/helpers.rs
+++ b/auth-service/tests/api/helpers.rs
@@ -90,9 +90,13 @@ impl TestApp {
             .expect("Failed to execute request.")
     }
 
-    pub async fn verify_token_root(&self) -> reqwest::Response {
+    pub async fn post_verify_token<Body>(&self, body: &Body) -> reqwest::Response
+    where
+        Body: serde::Serialize,
+    {
         self.http_client
             .post(&format!("{}/verify-token", &self.address))
+            .json(body)
             .send()
             .await
             .expect("Failed to execute request.")

--- a/auth-service/tests/api/verify_token.rs
+++ b/auth-service/tests/api/verify_token.rs
@@ -1,10 +1,43 @@
-use crate::helpers::TestApp;
+use auth_service::{domain::Email, utils::generate_auth_cookie};
 
+use crate::helpers::{get_random_email, TestApp};
 
 #[tokio::test]
-pub async fn root_returns_verify_token() {
+async fn should_return_200_valid_token() {
     let app = TestApp::new().await;
-    let response = app.verify_token_root().await;
 
-    assert_eq!(response.status().as_u16(), 200);
+    let email = Email::parse(get_random_email()).unwrap();
+    let cookie = generate_auth_cookie(&email).unwrap();
+
+    let token = serde_json::json!({
+        "token": cookie.value()
+    });
+
+    let response = app.post_verify_token(&token).await;
+
+    assert_eq!(response.status().as_u16(), 200)
+}
+
+#[tokio::test]
+async fn should_return_401_if_invalid_token() {
+    let app = TestApp::new().await;
+
+    let token = serde_json::json!({
+        "token": "invalidToken"
+    });
+
+    let response = app.post_verify_token(&token).await;
+
+    assert_eq!(response.status().as_u16(), 400)
+}
+
+#[tokio::test]
+async fn should_return_422_if_malformed_input() {
+    let app = TestApp::new().await;
+
+    let token = serde_json::json!({});
+
+    let response = app.post_verify_token(&token).await;
+
+    assert_eq!(response.status().as_u16(), 422)
 }


### PR DESCRIPTION
Add complete token verification functionality to the auth service:
- Create verify_token endpoint that accepts and validates JWT tokens
- Add VerifyTokenRequest and VerifyTokenResponse structs for request/response handling
- Integrate validate_token utility to verify token authenticity
- Return 200 for valid tokens, 400 for invalid tokens, and 422 for malformed requests
- Add comprehensive test coverage including valid token, invalid token, and malformed input scenarios
- Update test helper to support JSON body in verify_token requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Token verification endpoint now properly validates authentication tokens against requests.
* Added appropriate error responses: 400 status for invalid tokens and 422 status for malformed payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->