### PR TITLE
Add banned token store functionality for JWT logout

### DIFF
--- a/auth-service/src/api/helpers.rs
+++ b/auth-service/src/api/helpers.rs
@@ -1,4 +1,8 @@
-use crate::{app_state::AppState, services::HashmapUserStore, Application};
+use crate::{
+    app_state::AppState,
+    services::{HashmapUserStore, HashsetBannedTokenStore},
+    Application,
+};
 
 use fake::{
     faker::internet::en::{self, SafeEmail},
@@ -16,7 +20,9 @@ pub struct TestApp {
 impl TestApp {
     pub async fn new() -> Self {
         let user_store = Arc::new(RwLock::new(HashmapUserStore::default()));
-        let app_state = AppState::new(user_store);
+        let banned_store = Arc::new(RwLock::new(HashsetBannedTokenStore::default()));
+
+        let app_state = AppState::new(user_store, banned_store);
 
         let address = "127.0.0.1:0";
 

--- a/auth-service/src/app_state/app_state.rs
+++ b/auth-service/src/app_state/app_state.rs
@@ -1,17 +1,22 @@
-use crate::domain::UserStore;
+use crate::domain::{BannedTokenStore, UserStore};
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 pub type UserStoreType = Arc<RwLock<dyn UserStore + Send + Sync>>;
+pub type BannedTokenStoreType = Arc<RwLock<dyn BannedTokenStore + Send + Sync>>;
 
 #[derive(Clone)]
 pub struct AppState {
     pub user_store: UserStoreType,
+    pub banned_store: BannedTokenStoreType,
 }
 
 impl AppState {
-    pub fn new(user_store: UserStoreType) -> Self {
-        Self { user_store }
+    pub fn new(user_store: UserStoreType, banned_store: BannedTokenStoreType) -> Self {
+        Self {
+            user_store,
+            banned_store,
+        }
     }
 }

--- a/auth-service/src/domain/data_store.rs
+++ b/auth-service/src/domain/data_store.rs
@@ -1,4 +1,15 @@
+use axum_extra::extract::cookie::Cookie;
+
 use crate::domain::{Email, Password, User};
+
+#[derive(Debug, PartialEq)]
+pub enum UserStoreError {
+    UserAlreadyExists,
+    UserNotFound,
+    InvalidCredentials,
+    UnexpectedError,
+    IncorrectCredentials,
+}
 
 #[async_trait::async_trait]
 pub trait UserStore: Send + Sync {
@@ -9,10 +20,13 @@ pub trait UserStore: Send + Sync {
 }
 
 #[derive(Debug, PartialEq)]
-pub enum UserStoreError {
-    UserAlreadyExists,
-    UserNotFound,
-    InvalidCredentials,
-    UnexpectedError,
-    IncorrectCredentials,
+pub enum BannedTokenStoreError {
+    TokenNotFound,
+    FailedToStoreToken,
+}
+
+#[async_trait::async_trait]
+pub trait BannedTokenStore: Send + Sync {
+    fn store_token(&mut self, token: &str) -> Result<(), BannedTokenStoreError>;
+    fn has_token(&self, token: &str) -> bool;
 }

--- a/auth-service/src/main.rs
+++ b/auth-service/src/main.rs
@@ -1,11 +1,18 @@
-use auth_service::{app_state::AppState, services::HashmapUserStore, utils::prod, Application};
+use auth_service::{
+    app_state::AppState,
+    services::{HashmapUserStore, HashsetBannedTokenStore},
+    utils::prod,
+    Application,
+};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
 #[tokio::main]
 async fn main() {
     let user_store = Arc::new(RwLock::new(HashmapUserStore::default()));
-    let app_state = AppState::new(user_store);
+    let banned_token_store = Arc::new(RwLock::new(HashsetBannedTokenStore::default()));
+
+    let app_state = AppState::new(user_store, banned_token_store);
 
     let app = Application::build(app_state, prod::APP_ADDRESS)
         .await

--- a/auth-service/src/routes/verify_token.rs
+++ b/auth-service/src/routes/verify_token.rs
@@ -14,8 +14,9 @@ pub struct VerifyTokenResponse {
 }
 
 pub async fn verify_token_handler(Json(request): Json<VerifyTokenRequest>) -> impl IntoResponse {
-    match validate_token(&request.token).await {
-        Ok(_) => Ok(()),
-        Err(_) => Err(AuthAPIError::InvalidCredentials),
+    if validate_token(&request.token).await.is_err() {
+        return Err(AuthAPIError::InvalidToken);
     }
+
+    Ok(())
 }

--- a/auth-service/src/services/hashset_banned_token_store.rs
+++ b/auth-service/src/services/hashset_banned_token_store.rs
@@ -1,0 +1,46 @@
+use std::collections::HashSet;
+
+use crate::domain::{BannedTokenStore, BannedTokenStoreError};
+
+#[derive(Default, PartialEq, Clone)]
+pub struct HashsetBannedTokenStore {
+    tokens: HashSet<String>,
+}
+
+impl BannedTokenStore for HashsetBannedTokenStore {
+    fn store_token(&mut self, token: &str) -> Result<(), BannedTokenStoreError> {
+        match self.tokens.insert(token.into()) {
+            true => Ok(()),
+            false => Err(BannedTokenStoreError::FailedToStoreToken),
+        }
+    }
+
+    fn has_token(&self, token: &str) -> bool {
+        self.tokens.contains(token)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{domain::BannedTokenStore, services::HashsetBannedTokenStore};
+
+    #[test]
+    fn test_store_token() {
+        let mut banned_token_store = HashsetBannedTokenStore::default();
+        let token = "token";
+
+        let response = banned_token_store.store_token(token);
+
+        assert_eq!(response, Ok(()))
+    }
+
+    #[test]
+    fn test_has_toke() {
+        let mut banned_token_store = HashsetBannedTokenStore::default();
+        let token = "token";
+
+        banned_token_store.store_token(token).unwrap();
+
+        assert!(banned_token_store.has_token(token))
+    }
+}

--- a/auth-service/src/services/mod.rs
+++ b/auth-service/src/services/mod.rs
@@ -1,3 +1,5 @@
+mod hashset_banned_token_store;
 mod hashmap_user_store;
 
+pub use hashset_banned_token_store::*;
 pub use hashmap_user_store::*;

--- a/auth-service/tests/api/helpers.rs
+++ b/auth-service/tests/api/helpers.rs
@@ -1,22 +1,32 @@
-use auth_service::{app_state::AppState, services::HashmapUserStore, utils::test, Application};
+use auth_service::{
+    app_state::AppState,
+    services::{HashmapUserStore, HashsetBannedTokenStore},
+    utils::test,
+    Application,
+};
 use fake::{
     faker::internet::en::{self, SafeEmail},
     Fake,
 };
 use reqwest::cookie::Jar;
+use serde::{Deserialize, Serialize};
 use std::{ops::Range, sync::Arc};
 use tokio::sync::RwLock;
 
+#[derive(Clone)]
 pub struct TestApp {
     pub address: String,
     pub cookie_jar: Arc<Jar>,
     pub http_client: reqwest::Client,
+    pub banned_token_store: Arc<RwLock<HashsetBannedTokenStore>>,
 }
 
 impl TestApp {
     pub async fn new() -> Self {
         let user_store = Arc::new(RwLock::new(HashmapUserStore::default()));
-        let app_state = AppState::new(user_store);
+        let banned_token_store = Arc::new(RwLock::new(HashsetBannedTokenStore::default()));
+
+        let app_state = AppState::new(user_store, banned_token_store.clone());
 
         let app = Application::build(app_state, test::APP_ADDRESS)
             .await
@@ -39,6 +49,7 @@ impl TestApp {
             address,
             cookie_jar,
             http_client,
+            banned_token_store,
         }
     }
 

--- a/auth-service/tests/api/login.rs
+++ b/auth-service/tests/api/login.rs
@@ -105,27 +105,24 @@ pub async fn should_return_401_if_incorrect_credentials() {
     )
 }
 
-// #[tokio::test]
-// pub async fn should_return_422_if_malformed_credentials() {
-//     let app = TestApp::new().await;
+#[tokio::test]
+pub async fn should_return_422_if_malformed_credentials() {
+    let app = TestApp::new().await;
 
-//     let email = get_random_email();
-//     let password = get_random_password();
+    let email = get_random_email();
+    let password = get_random_password();
 
-//     let credentials = serde_json::json!(SignupRequest {
-//         email,
-//         password,
-//         requires_2fa: true
-//     });
+    let credentials = serde_json::json!(SignupRequest {
+        email,
+        password,
+        requires_2fa: true
+    });
 
-//     app.post_signup(&credentials).await;
+    app.post_signup(&credentials).await;
 
-//     let invalid_credentials = serde_json::json!(LoginRequest {
-//         email: "hello world".into(),
-//         password: "".into(),
-//     });
+    let malformed_credentials = serde_json::json!({});
 
-//     let response = app.login_root(&invalid_credentials).await;
+    let response = app.post_login(&malformed_credentials).await;
 
-//     assert_eq!(response.status().as_u16(), 422)
-// }
+    assert_eq!(response.status().as_u16(), 422)
+}

--- a/auth-service/tests/api/logout.rs
+++ b/auth-service/tests/api/logout.rs
@@ -2,7 +2,7 @@ use crate::helpers::TestApp;
 
 use auth_service::{
     api::get_random_email,
-    domain::Email,
+    domain::{BannedTokenStore, Email},
     utils::{generate_auth_cookie, JWT_COOKIE_NAME},
 };
 use reqwest::Url;
@@ -25,7 +25,10 @@ async fn should_return_200_if_valid_jwt_cookie() {
 
     let response = app.post_logout().await;
 
-    assert_eq!(response.status().as_u16(), 200)
+    assert_eq!(response.status().as_u16(), 200);
+
+    let banned_token_store = app.banned_token_store.read().await;
+    assert!(banned_token_store.has_token(cookie.value()))
 }
 
 #[tokio::test]
@@ -76,3 +79,15 @@ async fn should_return_401_if_invalid_token() {
 
     assert_eq!(response.status().as_u16(), 401)
 }
+
+// #[tokio::test]
+// async fn should_return_422_if_malformed_credentials() {
+//     let app = TestApp::new().await;
+
+//     let email = Email::parse(get_random_email()).unwrap();
+//     let cookie = generate_auth_cookie(&email).unwrap();
+
+//     let response = app.post_logout().await;
+
+//     assert_eq!(response.status().as_u16(), 422)
+// }


### PR DESCRIPTION
Implement HashsetBannedTokenStore to track invalidated JWT tokens on logout. The store uses a HashSet to maintain banned tokens in memory and integrates with the logout handler to prevent reuse of logged-out tokens.

Changes:
- Create HashsetBannedTokenStore implementation with store_token and has_token methods
- Update BannedTokenStore trait to use &str instead of Cookie for better separation of concerns
- Integrate banned token store into logout handler to store tokens on logout
- Add banned_store field to TestApp for testing banned token functionality
- Add unit tests for HashsetBannedTokenStore
- Update logout tests to verify tokens are added to banned store

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token banning mechanism that prevents reuse of logged-out tokens.

* **Bug Fixes**
  * Improved token verification to reject banned tokens with proper HTTP 401 response.
  * Enhanced error responses for invalid token scenarios.

* **Tests**
  * Added tests validating token banning functionality.
  * Activated test coverage for malformed credential scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->