### PR TITLE
Refactor BannedTokenStore to use async methods and improve token vali…

### DIFF
--- a/auth-service/src/domain/data_store.rs
+++ b/auth-service/src/domain/data_store.rs
@@ -27,6 +27,6 @@ pub enum BannedTokenStoreError {
 
 #[async_trait::async_trait]
 pub trait BannedTokenStore: Send + Sync {
-    fn store_token(&mut self, token: &str) -> Result<(), BannedTokenStoreError>;
-    fn has_token(&self, token: &str) -> bool;
+    async fn add_token(&mut self, token: String) -> Result<(), BannedTokenStoreError>;
+    async fn contains_token(&self, token: &str) -> Result<bool, BannedTokenStoreError>;
 }

--- a/auth-service/src/routes/login.rs
+++ b/auth-service/src/routes/login.rs
@@ -1,6 +1,6 @@
 use crate::{
     app_state::AppState,
-    domain::{AuthAPIError, Email, Password, User, UserStore},
+    domain::{AuthAPIError, Email, Password},
     utils::generate_auth_cookie,
 };
 
@@ -60,20 +60,4 @@ fn parse_credentials(email: String, password: String) -> Result<(Email, Password
     let password = Password::parse(password).map_err(|_| AuthAPIError::InvalidCredentials)?;
 
     Ok((email, password))
-}
-
-async fn get_user(
-    user_store: &(dyn UserStore + Send + Sync),
-    email: &Email,
-    password: &Password,
-) -> Result<User, AuthAPIError> {
-    user_store
-        .validate_user(&email, &password)
-        .await
-        .map_err(|_| AuthAPIError::IncorrectCredentials)?;
-
-    match user_store.get_user(&email).await {
-        Ok(user) => Ok(user),
-        Err(_) => Err(AuthAPIError::IncorrectCredentials),
-    }
 }

--- a/auth-service/src/routes/verify_token.rs
+++ b/auth-service/src/routes/verify_token.rs
@@ -17,7 +17,10 @@ pub async fn verify_token_handler(
     State(state): State<AppState>,
     Json(request): Json<VerifyTokenRequest>,
 ) -> impl IntoResponse {
-    if validate_token(&request.token).await.is_err() {
+    if validate_token(&request.token, state.banned_token_store)
+        .await
+        .is_err()
+    {
         return Err(AuthAPIError::InvalidToken);
     }
 

--- a/auth-service/src/services/hashset_banned_token_store.rs
+++ b/auth-service/src/services/hashset_banned_token_store.rs
@@ -7,40 +7,40 @@ pub struct HashsetBannedTokenStore {
     tokens: HashSet<String>,
 }
 
+#[async_trait::async_trait]
 impl BannedTokenStore for HashsetBannedTokenStore {
-    fn store_token(&mut self, token: &str) -> Result<(), BannedTokenStoreError> {
-        match self.tokens.insert(token.into()) {
-            true => Ok(()),
-            false => Err(BannedTokenStoreError::FailedToStoreToken),
-        }
+    async fn add_token(&mut self, token: String) -> Result<(), BannedTokenStoreError> {
+        self.tokens.insert(token);
+        Ok(())
     }
 
-    fn has_token(&self, token: &str) -> bool {
-        self.tokens.contains(token)
+    async fn contains_token(&self, token: &str) -> Result<bool, BannedTokenStoreError> {
+        Ok(self.tokens.contains(token))
     }
 }
 
 #[cfg(test)]
-mod test {
-    use crate::{domain::BannedTokenStore, services::HashsetBannedTokenStore};
+mod tests {
+    use super::*;
+    #[tokio::test]
+    async fn test_add_token() {
+        let mut store = HashsetBannedTokenStore::default();
+        let token = "test_token".to_owned();
 
-    #[test]
-    fn test_store_token() {
-        let mut banned_token_store = HashsetBannedTokenStore::default();
-        let token = "token";
+        let result = store.add_token(token.clone()).await;
 
-        let response = banned_token_store.store_token(token);
-
-        assert_eq!(response, Ok(()))
+        assert!(result.is_ok());
+        assert!(store.tokens.contains(&token));
     }
 
-    #[test]
-    fn test_has_toke() {
-        let mut banned_token_store = HashsetBannedTokenStore::default();
-        let token = "token";
+    #[tokio::test]
+    async fn test_contains_token() {
+        let mut store = HashsetBannedTokenStore::default();
+        let token = "test_token".to_owned();
+        store.tokens.insert(token.clone());
 
-        banned_token_store.store_token(token).unwrap();
+        let result = store.contains_token(&token).await;
 
-        assert!(banned_token_store.has_token(token))
+        assert!(result.unwrap());
     }
 }

--- a/auth-service/src/services/mod.rs
+++ b/auth-service/src/services/mod.rs
@@ -1,5 +1,5 @@
-mod hashset_banned_token_store;
 mod hashmap_user_store;
+mod hashset_banned_token_store;
 
-pub use hashset_banned_token_store::*;
 pub use hashmap_user_store::*;
+pub use hashset_banned_token_store::*;

--- a/auth-service/tests/api/helpers.rs
+++ b/auth-service/tests/api/helpers.rs
@@ -1,5 +1,5 @@
 use auth_service::{
-    app_state::AppState,
+    app_state::{AppState, BannedTokenStoreType},
     services::{HashmapUserStore, HashsetBannedTokenStore},
     utils::test,
     Application,
@@ -9,7 +9,6 @@ use fake::{
     Fake,
 };
 use reqwest::cookie::Jar;
-use serde::{Deserialize, Serialize};
 use std::{ops::Range, sync::Arc};
 use tokio::sync::RwLock;
 
@@ -17,8 +16,8 @@ use tokio::sync::RwLock;
 pub struct TestApp {
     pub address: String,
     pub cookie_jar: Arc<Jar>,
+    pub banned_token_store: BannedTokenStoreType,
     pub http_client: reqwest::Client,
-    pub banned_token_store: Arc<RwLock<HashsetBannedTokenStore>>,
 }
 
 impl TestApp {

--- a/auth-service/tests/api/logout.rs
+++ b/auth-service/tests/api/logout.rs
@@ -4,6 +4,7 @@ use auth_service::{
     api::get_random_email,
     domain::{BannedTokenStore, Email},
     utils::{generate_auth_cookie, JWT_COOKIE_NAME},
+    ErrorResponse,
 };
 use reqwest::Url;
 
@@ -11,46 +12,54 @@ use reqwest::Url;
 async fn should_return_200_if_valid_jwt_cookie() {
     let app = TestApp::new().await;
 
-    let email = Email::parse(get_random_email()).unwrap();
-    let cookie = generate_auth_cookie(&email).unwrap();
+    let random_email = get_random_email();
 
-    app.cookie_jar.add_cookie_str(
-        &format!(
-            "{}={}; HttpOnly; SameSite=Lax; Secure; Path=/",
-            JWT_COOKIE_NAME,
-            cookie.value()
-        ),
-        &Url::parse("http://127.0.0.1").expect("Failed to parse URL"),
-    );
+    let signup_body = serde_json::json!({
+        "email": random_email,
+        "password": "password123",
+        "requires2FA": false
+    });
+
+    let response = app.post_signup(&signup_body).await;
+
+    assert_eq!(response.status().as_u16(), 201);
+
+    let login_body = serde_json::json!({
+        "email": random_email,
+        "password": "password123",
+    });
+
+    let response = app.post_login(&login_body).await;
+
+    assert_eq!(response.status().as_u16(), 200);
+
+    let auth_cookie = response
+        .cookies()
+        .find(|cookie| cookie.name() == JWT_COOKIE_NAME)
+        .expect("No auth cookie found");
+
+    assert!(!auth_cookie.value().is_empty());
+
+    let token = auth_cookie.value();
 
     let response = app.post_logout().await;
 
     assert_eq!(response.status().as_u16(), 200);
 
+    let auth_cookie = response
+        .cookies()
+        .find(|cookie| cookie.name() == JWT_COOKIE_NAME)
+        .expect("No auth cookie found");
+
+    assert!(auth_cookie.value().is_empty());
+
     let banned_token_store = app.banned_token_store.read().await;
-    assert!(banned_token_store.has_token(cookie.value()))
-}
+    let contains_token = banned_token_store
+        .contains_token(token)
+        .await
+        .expect("Failed to check if token is banned");
 
-#[tokio::test]
-async fn should_return_400_if_logout_called_twice_in_a_row() {
-    let app = TestApp::new().await;
-
-    let email = Email::parse(get_random_email()).unwrap();
-    let cookie = generate_auth_cookie(&email).unwrap();
-
-    app.cookie_jar.add_cookie_str(
-        &format!(
-            "{}={}; HttpOnly; SameSite=Lax; Secure; Path=/",
-            JWT_COOKIE_NAME,
-            cookie.value()
-        ),
-        &Url::parse("http://127.0.0.1").expect("Failed to parse URL"),
-    );
-
-    app.post_logout().await;
-    let response = app.post_logout().await;
-
-    assert_eq!(response.status().as_u16(), 400)
+    assert!(contains_token);
 }
 
 #[tokio::test]
@@ -59,7 +68,81 @@ async fn should_return_400_if_jwt_cookie_missing() {
 
     let response = app.post_logout().await;
 
-    assert_eq!(response.status().as_u16(), 400)
+    assert_eq!(
+        response.status().as_u16(),
+        400,
+        "The API did not return a 400 BAD REQUEST",
+    );
+
+    let auth_cookie = response
+        .cookies()
+        .find(|cookie| cookie.name() == JWT_COOKIE_NAME);
+
+    assert!(auth_cookie.is_none());
+
+    assert_eq!(
+        response
+            .json::<ErrorResponse>()
+            .await
+            .expect("Could not deserialize response body to ErrorResponse")
+            .error,
+        "Missing auth token".to_owned()
+    );
+}
+
+#[tokio::test]
+async fn should_return_400_if_logout_called_twice_in_a_row() {
+    let app = TestApp::new().await;
+
+    let random_email = get_random_email();
+
+    let signup_body = serde_json::json!({
+        "email": random_email,
+        "password": "password123",
+        "requires2FA": false
+    });
+
+    let response = app.post_signup(&signup_body).await;
+
+    assert_eq!(response.status().as_u16(), 201);
+
+    let login_body = serde_json::json!({
+        "email": random_email,
+        "password": "password123",
+    });
+
+    let response = app.post_login(&login_body).await;
+
+    assert_eq!(response.status().as_u16(), 200);
+
+    let auth_cookie = response
+        .cookies()
+        .find(|cookie| cookie.name() == JWT_COOKIE_NAME)
+        .expect("No auth cookie found");
+
+    assert!(!auth_cookie.value().is_empty());
+
+    let response = app.post_logout().await;
+    assert_eq!(response.status().as_u16(), 200);
+
+    let auth_cookie = response
+        .cookies()
+        .find(|cookie| cookie.name() == JWT_COOKIE_NAME)
+        .expect("No auth cookie found");
+
+    assert!(auth_cookie.value().is_empty());
+
+    let response = app.post_logout().await;
+    assert_eq!(response.status().as_u16(), 400);
+
+    assert_eq!(
+        response
+            .json::<ErrorResponse>()
+            .await
+            .expect("Could not deserialize response body to ErrorResponse")
+            .error,
+        "Missing auth token".to_owned()
+    );
 }
 
 #[tokio::test]
@@ -77,17 +160,20 @@ async fn should_return_401_if_invalid_token() {
 
     let response = app.post_logout().await;
 
-    assert_eq!(response.status().as_u16(), 401)
+    assert_eq!(response.status().as_u16(), 401);
+
+    let auth_cookie = response
+        .cookies()
+        .find(|cookie| cookie.name() == JWT_COOKIE_NAME);
+
+    assert!(auth_cookie.is_none());
+
+    assert_eq!(
+        response
+            .json::<ErrorResponse>()
+            .await
+            .expect("Could not deserialize response body to ErrorResponse")
+            .error,
+        "Invalid auth token".to_owned()
+    );
 }
-
-// #[tokio::test]
-// async fn should_return_422_if_malformed_credentials() {
-//     let app = TestApp::new().await;
-
-//     let email = Email::parse(get_random_email()).unwrap();
-//     let cookie = generate_auth_cookie(&email).unwrap();
-
-//     let response = app.post_logout().await;
-
-//     assert_eq!(response.status().as_u16(), 422)
-// }


### PR DESCRIPTION
…dation

Update the BannedTokenStore trait to use async methods with Result return types:
- Rename store_token() to add_token() with String parameter
- Rename has_token() to contains_token() returning Result<bool>
- Make all BannedTokenStore methods async

Integrate banned token checking into validate_token() function to prevent use of logged-out tokens. Update logout and verify_token handlers to use the new async BannedTokenStore API with proper error handling.

Update HashsetBannedTokenStore implementation and tests to use async/await pattern. Improve test coverage for logout and verify_token endpoints with integration tests that verify token banning behavior.

Remove unused get_user() helper function from login route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced token validation now checks against banned tokens during verification before JWT decoding.

* **Bug Fixes**
  * Improved logout flow to properly record and validate banned tokens.
  * Refined error handling for missing or invalid authentication tokens with specific error messages.

* **Refactor**
  * Upgraded token management operations to asynchronous processing for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->