### PR TITLE
Add email client integration to 2FA login flow Integrate email client functionality into the authentication service to send 2FA codes via email during the login process.

### DIFF
--- a/auth-service/src/api/helpers.rs
+++ b/auth-service/src/api/helpers.rs
@@ -1,6 +1,7 @@
 use crate::{
     app_state::app_state::AppState,
-    services::{HashmapTwoFACodeStore, HashmapUserStore, HashsetBannedTokenStore},
+    domain::EmailClient,
+    services::{HashmapTwoFACodeStore, HashmapUserStore, HashsetBannedTokenStore, MockEmailClient},
     Application,
 };
 
@@ -21,8 +22,9 @@ impl TestApp {
         let user_store = Arc::new(RwLock::new(HashmapUserStore::default()));
         let banned_token_store = Arc::new(RwLock::new(HashsetBannedTokenStore::default()));
         let two_fa_store = Arc::new(RwLock::new(HashmapTwoFACodeStore::default()));
+        let email_client = Arc::new(RwLock::new(MockEmailClient));
 
-        let app_state = AppState::new(user_store, banned_token_store, two_fa_store);
+        let app_state = AppState::new(user_store, banned_token_store, two_fa_store, email_client);
 
         let address = "127.0.0.1:0";
 

--- a/auth-service/src/app_state/app_state.rs
+++ b/auth-service/src/app_state/app_state.rs
@@ -1,4 +1,7 @@
-use crate::domain::data_stores::{BannedTokenStore, TwoFACodeStore, UserStore};
+use crate::domain::{
+    data_stores::{BannedTokenStore, TwoFACodeStore, UserStore},
+    EmailClient,
+};
 
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -6,12 +9,14 @@ use tokio::sync::RwLock;
 pub type UserStoreType = Arc<RwLock<dyn UserStore + Send + Sync>>;
 pub type BannedTokenStoreType = Arc<RwLock<dyn BannedTokenStore + Send + Sync>>;
 pub type TwoFACodeStoreType = Arc<RwLock<dyn TwoFACodeStore + Send + Sync>>;
+pub type EmailClientType = Arc<RwLock<dyn EmailClient + Send + Sync>>;
 
 #[derive(Clone)]
 pub struct AppState {
     pub user_store: UserStoreType,
     pub banned_token_store: BannedTokenStoreType,
     pub two_fa_code_store: TwoFACodeStoreType,
+    pub email_client: EmailClientType,
 }
 
 impl AppState {
@@ -19,11 +24,13 @@ impl AppState {
         user_store: UserStoreType,
         banned_token_store: BannedTokenStoreType,
         two_fa_code_store: TwoFACodeStoreType,
+        email_client: EmailClientType,
     ) -> Self {
         Self {
             user_store,
             banned_token_store,
             two_fa_code_store,
+            email_client,
         }
     }
 }

--- a/auth-service/src/domain/email_client.rs
+++ b/auth-service/src/domain/email_client.rs
@@ -1,0 +1,11 @@
+use super::Email;
+
+#[async_trait::async_trait]
+pub trait EmailClient {
+    async fn send_email(
+        &self,
+        recipient: &Email,
+        subject: &str,
+        content: &str,
+    ) -> Result<(), String>;
+}

--- a/auth-service/src/domain/mod.rs
+++ b/auth-service/src/domain/mod.rs
@@ -1,5 +1,9 @@
 pub mod data_stores;
 pub mod email;
+pub mod email_client;
 pub mod error;
 pub mod password;
 pub mod user;
+
+pub use email::*;
+pub use email_client::*;

--- a/auth-service/src/main.rs
+++ b/auth-service/src/main.rs
@@ -1,6 +1,6 @@
 use auth_service::{
     app_state::app_state::AppState,
-    services::{HashmapTwoFACodeStore, HashmapUserStore, HashsetBannedTokenStore},
+    services::{HashmapTwoFACodeStore, HashmapUserStore, HashsetBannedTokenStore, MockEmailClient},
     utils::constants::prod,
     Application,
 };
@@ -12,8 +12,9 @@ async fn main() {
     let user_store = Arc::new(RwLock::new(HashmapUserStore::default()));
     let banned_token_store = Arc::new(RwLock::new(HashsetBannedTokenStore::default()));
     let two_fa_store = Arc::new(RwLock::new(HashmapTwoFACodeStore::default()));
+    let email_client = Arc::new(RwLock::new(MockEmailClient));
 
-    let app_state = AppState::new(user_store, banned_token_store, two_fa_store);
+    let app_state = AppState::new(user_store, banned_token_store, two_fa_store, email_client);
 
     let app = Application::build(app_state, prod::APP_ADDRESS)
         .await

--- a/auth-service/src/routes/login.rs
+++ b/auth-service/src/routes/login.rs
@@ -102,6 +102,17 @@ async fn handle_2fa(
         return (jar, Err(AuthAPIError::UnexpectedError));
     }
 
+    let send_to_email_client: Result<(), String> = state
+        .email_client
+        .write()
+        .await
+        .send_email(&email, "2FA Code", "554875")
+        .await;
+
+    if send_to_email_client.is_err() {
+        return (jar, Err(AuthAPIError::UnexpectedError));
+    }
+
     let response = Json(LoginResponse::TwoFactorAuth(TwoFactorAuthResponse {
         login_attempt_id: login_attempt_id.into(),
         message: "2FA required".into(),

--- a/auth-service/src/services/mock_email_client.rs
+++ b/auth-service/src/services/mock_email_client.rs
@@ -1,0 +1,23 @@
+use crate::domain::{Email, EmailClient};
+
+pub struct MockEmailClient;
+
+#[async_trait::async_trait]
+impl EmailClient for MockEmailClient {
+    async fn send_email(
+        &self,
+        recipient: &Email,
+        subject: &str,
+        content: &str,
+    ) -> Result<(), String> {
+        // Our mock email client will simply log the recipient, subject, and content to standard output
+        println!(
+            "Sending email to {} with subject: {} and content: {}",
+            recipient.as_ref(),
+            subject,
+            content
+        );
+
+        Ok(())
+    }
+}

--- a/auth-service/src/services/mod.rs
+++ b/auth-service/src/services/mod.rs
@@ -1,7 +1,9 @@
 pub mod hashmap_two_fa_code_store;
-mod hashmap_user_store;
-mod hashset_banned_token_store;
+pub mod hashmap_user_store;
+pub mod hashset_banned_token_store;
+pub mod mock_email_client;
 
 pub use hashmap_two_fa_code_store::*;
 pub use hashmap_user_store::*;
 pub use hashset_banned_token_store::*;
+pub use mock_email_client::*;

--- a/auth-service/tests/api/helpers.rs
+++ b/auth-service/tests/api/helpers.rs
@@ -1,6 +1,6 @@
 use auth_service::{
     app_state::app_state::{AppState, BannedTokenStoreType, TwoFACodeStoreType, UserStoreType},
-    services::{HashmapTwoFACodeStore, HashmapUserStore, HashsetBannedTokenStore},
+    services::{HashmapTwoFACodeStore, HashmapUserStore, HashsetBannedTokenStore, MockEmailClient},
     utils::constants::test,
     Application,
 };
@@ -27,11 +27,13 @@ impl TestApp {
         let user_store = Arc::new(RwLock::new(HashmapUserStore::default()));
         let banned_token_store = Arc::new(RwLock::new(HashsetBannedTokenStore::default()));
         let two_fa_code_store = Arc::new(RwLock::new(HashmapTwoFACodeStore::default()));
-
+        let email_client = Arc::new(RwLock::new(MockEmailClient));
+        
         let app_state = AppState::new(
             user_store.clone(),
             banned_token_store.clone(),
             two_fa_code_store.clone(),
+            email_client.clone(),
         );
 
         let app = Application::build(app_state, test::APP_ADDRESS)


### PR DESCRIPTION
Changes:
- Add EmailClient trait defining async email sending interface
- Implement MockEmailClient for development and testing
- Update AppState to include email_client field with EmailClientType
- Integrate email sending in login 2FA flow (routes/login.rs)
- Update test helpers and main.rs to instantiate MockEmailClient
- Export email client types from domain module
- Make service modules public for proper access

The email client uses a trait-based design allowing for easy swapping between mock and production implementations. Currently sends hardcoded 2FA code "554875" to user's email during login.