### PR TITLE
Add Redis banned token store implementation and MySQL user store impr…

### DIFF
--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -25,5 +25,6 @@ FROM debian:buster-slim AS runtime
 WORKDIR /app
 COPY --from=builder /app/target/release/auth-service /usr/local/bin
 COPY --from=builder /app/assets /app/assets
+ENV REDIS_HOST_NAME=redis
 ENTRYPOINT ["/usr/local/bin/auth-service"]
 

--- a/auth-service/src/app_state/app_state.rs
+++ b/auth-service/src/app_state/app_state.rs
@@ -1,6 +1,6 @@
 use crate::{
     domain::{
-        data_stores::{BannedTokenStore, TwoFACodeStore},
+        data_stores::{BannedTokenStore, TwoFACodeStore, UserStore},
         EmailClient,
     },
     services::data_stores::MySqlUserStore,
@@ -9,7 +9,7 @@ use crate::{
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub type UserStoreType = Arc<RwLock<MySqlUserStore>>;
+pub type UserStoreType = Arc<RwLock<dyn UserStore + Send + Sync>>;
 pub type BannedTokenStoreType = Arc<RwLock<dyn BannedTokenStore + Send + Sync>>;
 pub type TwoFACodeStoreType = Arc<RwLock<dyn TwoFACodeStore + Send + Sync>>;
 pub type EmailClientType = Arc<RwLock<dyn EmailClient + Send + Sync>>;

--- a/auth-service/src/domain/data_stores.rs
+++ b/auth-service/src/domain/data_stores.rs
@@ -26,6 +26,7 @@ pub trait UserStore: Send + Sync {
 pub enum BannedTokenStoreError {
     TokenNotFound,
     FailedToStoreToken,
+    UnexpectedError,
 }
 
 #[async_trait::async_trait]

--- a/auth-service/src/lib.rs
+++ b/auth-service/src/lib.rs
@@ -1,6 +1,5 @@
 use crate::{
     app_state::app_state::AppState,
-    domain::error::AuthAPIError,
     routes::{
         login::login_handler, logout::logout_handler, signup::signup_handler,
         verify_2fa::verify_2fa_handler, verify_token::verify_token_handler,
@@ -8,15 +7,9 @@ use crate::{
     utils::constants::DATABASE_URL,
 };
 
-use axum::{
-    http::StatusCode,
-    response::{IntoResponse, Response},
-    routing::post,
-    serve::Serve,
-    Json, Router,
-};
+use axum::{routing::post, serve::Serve, Router};
+use redis::{Client, RedisResult};
 use reqwest::Method;
-use serde::{Deserialize, Serialize};
 use sqlx::{mysql::MySqlPoolOptions, MySqlPool};
 use std::error::Error;
 use tower_http::{cors::CorsLayer, services::ServeDir};
@@ -69,10 +62,6 @@ impl Application {
     }
 }
 
-
-
-
-
 pub async fn configure_mysql() -> MySqlPool {
     // Create a new database connection pool
     let mysql_pool = get_mysql_pool(&DATABASE_URL)
@@ -93,4 +82,9 @@ pub async fn get_mysql_pool(url: &str) -> Result<MySqlPool, sqlx::Error> {
         .max_connections(5)
         .connect(url)
         .await
+}
+
+pub fn get_redis_client(redis_hostname: String) -> RedisResult<Client> {
+    let redis_url = format!("redis://{}/", redis_hostname);
+    redis::Client::open(redis_url)
 }

--- a/auth-service/src/main.rs
+++ b/auth-service/src/main.rs
@@ -1,11 +1,11 @@
 use auth_service::{
     app_state::app_state::AppState,
-    configure_mysql,
+    configure_mysql, get_redis_client,
     services::{
         data_stores::{HashmapTwoFACodeStore, HashsetBannedTokenStore, MySqlUserStore},
         MockEmailClient,
     },
-    utils::constants::prod,
+    utils::constants::{prod, REDIS_HOST_NAME},
     Application,
 };
 
@@ -28,4 +28,11 @@ async fn main() {
         .expect("Failed to build app.");
 
     app.run().await.expect("Failed to run app.")
+}
+
+fn configure_redis() -> redis::Connection {
+    get_redis_client(REDIS_HOST_NAME.to_owned())
+        .expect("Failed to get Rediss client")
+        .get_connection()
+        .expect("Failed to get Redis connection")
 }

--- a/auth-service/src/services/data_stores/mod.rs
+++ b/auth-service/src/services/data_stores/mod.rs
@@ -2,8 +2,10 @@ pub mod hashmap_two_fa_code_store;
 pub mod hashmap_user_store;
 pub mod hashset_banned_token_store;
 pub mod mysql_user_store;
+pub mod redis_banned_token_store;
 
 pub use hashmap_two_fa_code_store::*;
 pub use hashmap_user_store::*;
 pub use hashset_banned_token_store::*;
 pub use mysql_user_store::*;
+pub use redis_banned_token_store::*;

--- a/auth-service/src/services/data_stores/redis_banned_token_store.rs
+++ b/auth-service/src/services/data_stores/redis_banned_token_store.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+
+use redis::{Commands, Connection, RedisError};
+use tokio::sync::RwLock;
+
+use crate::{
+    domain::data_stores::{BannedTokenStore, BannedTokenStoreError},
+    utils::constants::TOKEN_TTL_SECONDS,
+};
+
+pub struct RedisBannedTokenStore {
+    conn: Arc<RwLock<Connection>>,
+}
+
+impl RedisBannedTokenStore {
+    pub fn new(conn: Arc<RwLock<Connection>>) -> Self {
+        Self { conn }
+    }
+}
+
+#[async_trait::async_trait]
+impl BannedTokenStore for RedisBannedTokenStore {
+    async fn add_token(&mut self, token: String) -> Result<(), BannedTokenStoreError> {
+        let seconds: u64 = TOKEN_TTL_SECONDS
+            .try_into()
+            .map_err(|_| BannedTokenStoreError::UnexpectedError)?;
+        let conn = self.conn.clone();
+        let key = get_key(&token);
+
+        tokio::task::spawn_blocking(move || {
+            let mut connection = conn.blocking_write();
+            let _: () = connection.set_ex(key, true, seconds)?;
+
+            Ok::<(), RedisError>(())
+        })
+        .await
+        .map_err(|_| BannedTokenStoreError::UnexpectedError)?
+        .map_err(|_| BannedTokenStoreError::UnexpectedError)?;
+
+        Ok(())
+    }
+
+    async fn contains_token(&self, token: &str) -> Result<bool, BannedTokenStoreError> {
+        let key = get_key(token);
+        let conn = self.conn.clone();
+
+        let exists = tokio::task::spawn_blocking(move || {
+            let mut connection = conn.blocking_write();
+
+            let token_exist = connection.exists(&key)?;
+
+            Ok::<bool, RedisError>(token_exist)
+        })
+        .await
+        .map_err(|_| BannedTokenStoreError::UnexpectedError)?
+        .map_err(|_| BannedTokenStoreError::UnexpectedError)?;
+
+        Ok(exists)
+    }
+}
+
+// We are using a key prefix to prevent collisions and organize data!
+const BANNED_TOKEN_KEY_PREFIX: &str = "banned_token:";
+
+fn get_key(token: &str) -> String {
+    format!("{}{}", BANNED_TOKEN_KEY_PREFIX, token)
+}

--- a/auth-service/src/utils/constants.rs
+++ b/auth-service/src/utils/constants.rs
@@ -3,7 +3,10 @@ use lazy_static::lazy_static;
 use std::env as std_env;
 
 pub const TOKEN_TTL_SECONDS: i64 = 600; // Token valid for 10 minutes
+
 pub const JWT_COOKIE_NAME: &str = "jwt";
+
+pub const DEFAULT_REDIS_HOSTNAME: &str = "127.0.0.1";
 
 lazy_static! {
     pub static ref JWT_SECRET: String = set_token();
@@ -11,6 +14,7 @@ lazy_static! {
     pub static ref MYSQL_SERVER_URL: String = set_mysql_server_url();
     pub static ref MYSQL_PASSWORD: String = set_mysql_password();
     pub static ref MYSQL_ROOT_PASSWORD: String = set_mysql_root_password();
+    pub static ref REDIS_HOST_NAME: String = set_redis_host();
 }
 
 pub mod env {
@@ -19,6 +23,7 @@ pub mod env {
     pub const MYSQL_SERVER_URL_ENV_VAR: &str = "MYSQL_SERVER_URL";
     pub const MYSQL_PASSWORD_ENV_VAR: &str = "MYSQL_PASSWORD";
     pub const MYSQL_ROOT_PASSWORD_ENV_VAR: &str = "MYSQL_ROOT_PASSWORD";
+    pub const REDIS_HOST_NAME_ENV_VAR: &str = "REDIS_HOST_NAME";
 }
 
 pub mod prod {
@@ -84,4 +89,9 @@ fn set_mysql_root_password() -> String {
     }
 
     secret
+}
+
+fn set_redis_host() -> String {
+    dotenv().ok();
+    std_env::var(env::REDIS_HOST_NAME_ENV_VAR).unwrap_or(DEFAULT_REDIS_HOSTNAME.to_owned())
 }


### PR DESCRIPTION
…ovements

Implement RedisBannedTokenStore with token lifecycle management:
- Add banned token storage with TTL using Redis set_ex command
- Implement token existence checking with key prefix isolation
- Use spawn_blocking for Redis blocking operations with Arc<RwLock<Connection>>
- Add explicit type annotations for Rust 2024 compatibility

Update MySQL user store with improved type safety:
- Refactor get_user to use manual query parsing with Email::parse validation
- Remove From<String> trait implementations to enforce Email/Password validation
- Add password hashing with Argon2 in async blocking tasks
- Implement test database lifecycle with UUID-based isolation

Configure Redis integration:
- Add Redis Docker service to docker-compose.yml
- Update Dockerfile with Redis dependencies
- Configure Redis connection in app_state module
- Export configure_mysql for shared use across crates

Improve project configuration:
- Add comprehensive .gitignore for build artifacts, env files, and IDE files
- Remove tracked target/ and .sqlx/ files from git

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redis-backed banned token storage system
  * Introduced environment variable configuration for Redis host with local default

* **Improvements**
  * Expanded error handling for storage operations
  * Updated application architecture to support flexible data store implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->